### PR TITLE
Add Rviz2 package for Apple M1

### DIFF
--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -35,6 +35,7 @@ packages_select_by_deps:
   - ros_environment
   - ros_base
   - desktop
+  - rviz2
 
   # - navigation2
   # - ament-uncrustify


### PR DESCRIPTION
RViz is very useful tool and still it is missing on ROS2 envs in Apple Silicon (M1 chips).

-- I can test M1 builds, if that helps the project...