### PR TITLE
Add libi2c-dev rosdep key

### DIFF
--- a/robostack.yaml
+++ b/robostack.yaml
@@ -260,6 +260,8 @@ libgts:
   robostack: [gts]
 libhdf5-dev:
   robostack: [hdf5]
+libi2c-dev:
+  robostack: [libi2c]
 libjpeg:
   robostack: [libjpeg-turbo]
 libjsoncpp:


### PR DESCRIPTION
The `libi2c` package was added in conda-forge in https://github.com/conda-forge/staged-recipes/pull/17583, and the ros key is defined in https://github.com/ros/rosdistro/blob/4591f64be84c04dda93f13ba858020f345a00b4d/rosdep/base.yaml#L3509 .  I am not sure which package depends on it, but better add it before we forget about it.